### PR TITLE
Adds CustomWebView to show websites in app

### DIFF
--- a/CIRN-2025/Shared Views/CustomWebView.swift
+++ b/CIRN-2025/Shared Views/CustomWebView.swift
@@ -24,5 +24,5 @@ struct CustomWebView: UIViewRepresentable {
 
 #Preview {
 	
-	CustomWebView(url: URL(string: "https://sarunw.com/posts/swiftui-webview/")!)
+	CustomWebView(url: URL(string: "https://mfgren.my.site.com/cirnapp/")!)
 }


### PR DESCRIPTION
Summary: 
Adds the `CustomWebView` using `WebKit`, to be able to show websites inside the app.

Note: There is a newer version of `WebView` built specifically for SwiftUI that is set for `iOS 26`


`WebKit for SwiftUI in iOS26` : https://developer.apple.com/videos/play/wwdc2025/231/
Apple Developer App: https://apps.apple.com/us/app/apple-developer/id640199958

