### PR TITLE
Fix: Updated About Us URL

### DIFF
--- a/CIRN-2025/Shared Views/AboutUsView.swift
+++ b/CIRN-2025/Shared Views/AboutUsView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct AboutUsView: View {
     var body: some View {
         NavigationStack {
-            CustomWebView(url: URL(string: "https://mfgren.my.site.com/cirnapp/")!)
+            CustomWebView(url: URL(string: "https://www.mfgren.org/cirn/")!)
                 .navigationTitle("About Us")
                 .navigationBarTitleDisplayMode(.inline)
         }


### PR DESCRIPTION
Summary
Updated the URL on the About Us page from https://mfgren.my.site.com/cirnapp/ to https://www.mfgren.org/cirn/

![Simulator Screenshot - iPhone 16 Pro - 2025-07-09 at 11 48 29](https://github.com/user-attachments/assets/b0df44c7-e1e5-47ae-b57a-29233be4adcf)
